### PR TITLE
Update lookup.js

### DIFF
--- a/resources/js/lookup.js
+++ b/resources/js/lookup.js
@@ -12,7 +12,9 @@ $(function () {
 
             e.preventDefault();
 
-            wrapper.find('.selected').load('/streams/relationship-field_type/selected/' + $(this).data('key') + '?uploaded=' + $(this).data('entry'));
+            wrapper.find('.selected').load('/streams/relationship-field_type/selected/' + $(this).data('key') + '?uploaded=' + $(this).data('entry'), function () {
+                modal.modal('hide');
+            });
 
             $('[name="' + field + '"]').val($(this).data('entry'));
 


### PR DESCRIPTION
Reverting removal of modal.modal('hide').  Modals are no longer properly closing after this update
