### PR TITLE
Making work on subfolder installations

### DIFF
--- a/resources/js/lookup.js
+++ b/resources/js/lookup.js
@@ -12,7 +12,7 @@ $(function () {
 
             e.preventDefault();
 
-            wrapper.find('.selected').load('/streams/relationship-field_type/selected/' + $(this).data('key') + '?uploaded=' + $(this).data('entry'), function () {
+            wrapper.find('.selected').load(REQUEST_ROOT_PATH + '/streams/relationship-field_type/selected/' + $(this).data('key') + '?uploaded=' + $(this).data('entry'), function () {
                 modal.modal('hide');
             });
 


### PR DESCRIPTION
Added `REQUEST_ROOT_PATH` to make work in subfolder installations. Previously the lookup folder was 404ing after an entry was selected and the selection wasn't display in the form (e.g., when selecting pages for links in the navigation module).