### PR TITLE
Add option group support to the filter

### DIFF
--- a/resources/views/filter.twig
+++ b/resources/views/filter.twig
@@ -4,7 +4,16 @@
 
     <option value="" disabled {{ not field_type.value ? 'selected' }}>{{ trans(field_type.placeholder) }}</option>
 
-    {% for value, title in field_type.options %}
-        <option value="{{ value }}" {{ field_type.value == value ? 'selected' }}>{{ trans(title) }}</option>
+    {% for value, option in field_type.options %}
+        {% if option is iterable %}
+            <optgroup label="{{ trans(value) }}">
+                {% for value, option in option %}
+                    <option value="{{ value }}" {{ field_type.value == value ? 'selected' }}>{{ trans(option) }}</option>
+                {% endfor %}
+            </optgroup>
+        {% else %}
+            <option value="{{ value }}" {{ field_type.value == value ? 'selected' }}>{{ trans(option) }}</option>
+        {% endif %}
     {% endfor %}
 </select>
+


### PR DESCRIPTION
Setting a handler on a field that uses `<optgroup>` throws a twig error when the filter dropdown is rendered. This adds support for them, while still keeping compatibility with the non-optgroup-using filter dropdowns.