### PR TITLE
Fix placeholder

### DIFF
--- a/src/RelationshipFieldType.php
+++ b/src/RelationshipFieldType.php
@@ -241,7 +241,7 @@ class RelationshipFieldType extends FieldType
      */
     public function getPlaceholder()
     {
-        if (!$this->placeholder && !$this->isRequired()) {
+        if (!$this->placeholder) {
             return 'anomaly.field_type.relationship::input.placeholder';
         }
 


### PR DESCRIPTION
Removed the isRequried() logic for getting the placeholder as it makes no sense what so ever.

If the field is required, that should force them to make a selection, not default it to the first returned entry