### PR TITLE
Use Crypt instead of cache

### DIFF
--- a/src/Command/GetConfiguration.php
+++ b/src/Command/GetConfiguration.php
@@ -2,6 +2,7 @@
 
 use Anomaly\Streams\Platform\Support\Collection;
 use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Support\Facades\Crypt;
 
 class GetConfiguration
 {
@@ -31,8 +32,8 @@ class GetConfiguration
      */
     public function handle(Repository $cache)
     {
-        return new Collection(
-            array_merge($cache->get('anomaly/relationship-field_type::' . $this->key), ['key' => $this->key])
+       return new Collection(
+            array_merge(Crypt::decrypt($this->key), ['key' => $this->key])
         );
     }
 }

--- a/src/RelationshipFieldType.php
+++ b/src/RelationshipFieldType.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Support\Facades\Crypt;
 
 /**
  * Class RelationshipFieldType
@@ -131,13 +132,7 @@ class RelationshipFieldType extends FieldType
      */
     public function key()
     {
-        $this->cache->put(
-            'anomaly/relationship-field_type::' . ($key = md5(json_encode($this->getConfig()))),
-            $this->getConfig(),
-            30
-        );
-
-        return $key;
+       return Crypt::encrypt($this->getConfig());
     }
 
     /**


### PR DESCRIPTION
Cache is randomly busting during the same page load for lookup builders. This removes this issue and hashes the config to be accessed between loads.

Multiple FT has the same bug, if approved will patch multiple-ft as well.