### PR TITLE
Added attributes to dropdown

### DIFF
--- a/resources/views/dropdown.twig
+++ b/resources/views/dropdown.twig
@@ -1,6 +1,7 @@
 <select
         class="{{ field_type.class }}"
         name="{{ field_type.input_name }}"
+        {{ html_attributes(field_type.attributes) }}
         {{ field_type.disabled ? 'disabled' }}
         {{ field_type.readonly ? 'readonly' }}>
 


### PR DESCRIPTION
No sure why but `dropdown.twig` is the only field w/o attributes (so we cannot use JS on it).